### PR TITLE
Fix/improving showing trees

### DIFF
--- a/include/Trees/AVL/AVLTree.hpp
+++ b/include/Trees/AVL/AVLTree.hpp
@@ -23,6 +23,8 @@ template <typename Key, typename Value>
 class AVLTree : public IDictionary<Key, Value>, public BaseTree<AVLTree<Key, Value>, AVLNode<Key, Value>, Key, Value> {
 private:
     AVLNode<Key, Value>* root; ///< Pointer to the root node of the AVL tree.
+    size_t maxKeyLen;
+    size_t maxValLen;
 
     /**
      * @brief Retrieves the root node of the AVL tree.
@@ -134,6 +136,20 @@ private:
      */
     AVLNode<Key, Value>* remove(const Key& key, AVLNode<Key, Value>* node);
 
+    /**
+     * @brief Inserts or updates a key-value pair in the AVL tree.
+     * @param key The key to be inserted or updated.
+     * @param node The current node being processed in the recursive call.
+     * @param outValue A reference to a pointer that will store the address of the value associated with the key.
+     * @return A pointer to the balanced node after insertion or update.
+     * @details This method handles both insertion of new nodes and updating existing
+     * node values. It recursively traverses the tree to find the correct position
+     * for the key. If the key is found, `outValue` is set to point to the existing
+     * value. If a new node is created, `outValue` points to its new value.
+     * It also updates `maxKeyLen` and `maxValLen` based on the display size
+     * of the key and value, and performs AVL tree rotations via `fixupNode`
+     * to maintain balance.
+     */
     AVLNode<Key, Value>* upsert(const Key& key, AVLNode<Key, Value>* node, Value*& outValue);
 public:
     static const int IMBALANCE = 2; ///< The imbalance threshold for the AVL tree.
@@ -149,11 +165,12 @@ public:
     ~AVLTree();
 
     /**
-     * @brief Inserts a key-value pair into the AVL tree.
-     * 
-     * @param key The key to insert.
+     * @brief Inserts a new key-value pair into the AVL tree.
+     * @param key The key to be inserted.
      * @param value The value associated with the key.
-     * @throws KeyAlreadyExistsException If the key already exists in the tree.
+     * @details This method updates the `root` of the AVL tree after insertion
+     * and also updates `maxKeyLen` and `maxValLen` based on the
+     * display size of the inserted key and value, respectively.
      */
     void insert(const Key& key, const Value& value) override;
 

--- a/include/Trees/AVL/AVLTree.impl.hpp
+++ b/include/Trees/AVL/AVLTree.impl.hpp
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <cmath>
 
+#include "Utils/StringHandler.hpp"
+
 template <typename Key, typename Value>
 const AVLNode<Key, Value>* AVLTree<Key, Value>::getRoot() const {
 	return root;
@@ -158,9 +160,12 @@ AVLNode<Key, Value>* AVLTree<Key, Value>::remove(const Key& key, AVLNode<Key, Va
 
 template <typename Key, typename Value>
 AVLNode<Key, Value>* AVLTree<Key, Value>::upsert(const Key& key, AVLNode<Key, Value>* node, Value*& outValue) {
+	maxKeyLen = std::max(maxKeyLen, StringHandler::size(key));
+
 	if (!node) {
 		AVLNode<Key, Value>* newNode = new AVLNode<Key, Value>(key, Value());
 		outValue = &(newNode->getValue());
+		maxValLen = std::max(maxValLen, StringHandler::size(outValue));
 		return newNode;
 	}
 
@@ -172,6 +177,7 @@ AVLNode<Key, Value>* AVLTree<Key, Value>::upsert(const Key& key, AVLNode<Key, Va
 		node->right = upsert(key, node->right, outValue);
 	} else {
 		outValue = &(node->getValue());
+		maxValLen = std::max(maxValLen, StringHandler::size(outValue));
 		return node;
 	}
 
@@ -179,7 +185,7 @@ AVLNode<Key, Value>* AVLTree<Key, Value>::upsert(const Key& key, AVLNode<Key, Va
 }
 
 template <typename Key, typename Value>
-AVLTree<Key, Value>::AVLTree(): root(nullptr) {}
+AVLTree<Key, Value>::AVLTree(): root(nullptr), maxKeyLen(0), maxValLen(0) {}
 
 template <typename Key, typename Value>
 AVLTree<Key, Value>::~AVLTree() { clear(); }
@@ -187,6 +193,8 @@ AVLTree<Key, Value>::~AVLTree() { clear(); }
 template <typename Key, typename Value>
 void AVLTree<Key, Value>::insert(const Key& key, const Value& value) {
 	root = insert(key, value, root);
+	maxKeyLen = std::max(maxKeyLen, StringHandler::size(key));
+	maxValLen = std::max(maxValLen, StringHandler::size(value));
 }
 
 template  <typename Key, typename Value>

--- a/include/Trees/AVL/AVLTree.impl.hpp
+++ b/include/Trees/AVL/AVLTree.impl.hpp
@@ -160,12 +160,12 @@ AVLNode<Key, Value>* AVLTree<Key, Value>::remove(const Key& key, AVLNode<Key, Va
 
 template <typename Key, typename Value>
 AVLNode<Key, Value>* AVLTree<Key, Value>::upsert(const Key& key, AVLNode<Key, Value>* node, Value*& outValue) {
-	maxKeyLen = std::max(maxKeyLen, StringHandler::size(key));
+	this->setMaxKeyLen(key);
 
 	if (!node) {
 		AVLNode<Key, Value>* newNode = new AVLNode<Key, Value>(key, Value());
 		outValue = &(newNode->getValue());
-		maxValLen = std::max(maxValLen, StringHandler::size(outValue));
+		this->setMaxValLen(*outValue);
 		return newNode;
 	}
 
@@ -177,7 +177,7 @@ AVLNode<Key, Value>* AVLTree<Key, Value>::upsert(const Key& key, AVLNode<Key, Va
 		node->right = upsert(key, node->right, outValue);
 	} else {
 		outValue = &(node->getValue());
-		maxValLen = std::max(maxValLen, StringHandler::size(outValue));
+		this->setMaxValLen(*outValue);
 		return node;
 	}
 
@@ -193,8 +193,8 @@ AVLTree<Key, Value>::~AVLTree() { clear(); }
 template <typename Key, typename Value>
 void AVLTree<Key, Value>::insert(const Key& key, const Value& value) {
 	root = insert(key, value, root);
-	maxKeyLen = std::max(maxKeyLen, StringHandler::size(key));
-	maxValLen = std::max(maxValLen, StringHandler::size(value));
+	this->setMaxKeyLen(key);
+	this->setMaxValLen(value);
 }
 
 template  <typename Key, typename Value>

--- a/include/Trees/Base/BaseTree.hpp
+++ b/include/Trees/Base/BaseTree.hpp
@@ -46,7 +46,6 @@ class BaseTree {
      * @return The maximum display length of values encountered in the tree.
      */
     const size_t getMaxValLen() const;
-
 protected:
     /**
      * @brief Finds a node with the specified key in the tree.
@@ -85,6 +84,10 @@ protected:
      * @throws KeyNotFoundException If the key is not found in the tree.
      */
     const Value& at(const Key& key) const;
+
+    void setMaxKeyLen(const Key& key);
+
+    void setMaxValLen(const Value& value);
 };
 
 // Include the implementation file to provide the definitions for the template methods.

--- a/include/Trees/Base/BaseTree.hpp
+++ b/include/Trees/Base/BaseTree.hpp
@@ -33,6 +33,20 @@ class BaseTree {
      */
     const Node* getTreeRoot() const;
 
+    /**
+     * @brief Retrieves the maximum key length recorded in the derived tree.
+     * @tparam Value The type of the values stored in the tree.
+     * @return The maximum display length of keys encountered in the tree.
+     */
+    const size_t getMaxKeyLen() const;
+
+    /**
+     * @brief Retrieves the maximum value length recorded in the derived tree.
+     * @details This method uses CRTP to access the `maxValLen` member from the derived `Tree` object.
+     * @return The maximum display length of values encountered in the tree.
+     */
+    const size_t getMaxValLen() const;
+
 protected:
     /**
      * @brief Finds a node with the specified key in the tree.

--- a/include/Trees/Base/BaseTree.impl.hpp
+++ b/include/Trees/Base/BaseTree.impl.hpp
@@ -3,6 +3,8 @@
 
 #include "Trees/Base/BaseTree.hpp" 
 
+#include <cmath>
+
 #include "Utils/StringHandler.hpp"
 
 template <typename Tree, typename Node, typename Key, typename Value>
@@ -87,6 +89,16 @@ const Value& BaseTree<Tree, Node, Key, Value>::at(const Key& key) const {
     }
 
     throw KeyNotFoundException();
+}
+
+template <typename Tree, typename Node, typename Key, typename Value>
+void BaseTree<Tree, Node, Key, Value>::setMaxKeyLen(const Key& key) {
+    static_cast<Tree*>(this)->maxKeyLen = std::max(getMaxKeyLen(), StringHandler::size(key));
+}
+
+template <typename Tree, typename Node, typename Key, typename Value>
+void BaseTree<Tree, Node, Key, Value>::setMaxValLen(const Value& value) {
+    static_cast<Tree*>(this)->maxValLen = std::max(getMaxValLen(), StringHandler::size(value));
 }
 
 #endif 

--- a/include/Trees/Base/BaseTree.impl.hpp
+++ b/include/Trees/Base/BaseTree.impl.hpp
@@ -3,6 +3,8 @@
 
 #include "Trees/Base/BaseTree.hpp" 
 
+#include "Utils/StringHandler.hpp"
+
 template <typename Tree, typename Node, typename Key, typename Value>
 void BaseTree<Tree, Node, Key, Value>::count() const {
     static_cast<const Tree*>(this)->incrementCounter();
@@ -11,6 +13,16 @@ void BaseTree<Tree, Node, Key, Value>::count() const {
 template <typename Tree, typename Node, typename Key, typename Value>
 const Node* BaseTree<Tree, Node, Key, Value>::getTreeRoot() const {
     return static_cast<const Tree*>(this)->getRoot();
+}
+
+template <typename Tree, typename Node, typename Key, typename Value>
+const size_t BaseTree<Tree, Node, Key, Value>::getMaxKeyLen() const {
+    return static_cast<const Tree*>(this)->maxKeyLen;
+}
+
+template <typename Tree, typename Node, typename Key, typename Value>
+const size_t BaseTree<Tree, Node, Key, Value>::getMaxValLen() const {
+    return static_cast<const Tree*>(this)->maxValLen;
 }
 
 template <typename Tree, typename Node, typename Key, typename Value>
@@ -51,7 +63,8 @@ void BaseTree<Tree, Node, Key, Value>::inOrderTransversal(std::ostream& out, Nod
     if (node != comp) {
         inOrderTransversal(out, node->left, comp);
 
-        out << node->show() << '\n';
+        out << StringHandler::SetWidthAtLeft(node->getKey(), getMaxKeyLen()) << " | " 
+            << StringHandler::SetWidthAtLeft(node->getValue(), getMaxValLen()) << '\n';
 
         inOrderTransversal(out, node->right, comp);
     }

--- a/include/Trees/RedBlack/RedBlackTree.hpp
+++ b/include/Trees/RedBlack/RedBlackTree.hpp
@@ -24,6 +24,8 @@ private:
     RedBlackNode<Key, Value>* root; ///< Pointer to the root node of the Red-Black Tree.
     static RedBlackNode<Key, Value>* const NIL; ///< Sentinel node representing null leaves.
     int comparisonsCount;
+    size_t maxKeyLen;
+    size_t maxValLen;
 
     /**
      * @brief Retrieves the root node of the Red-Black Tree.

--- a/include/Trees/RedBlack/RedBlackTree.impl.hpp
+++ b/include/Trees/RedBlack/RedBlackTree.impl.hpp
@@ -109,7 +109,7 @@ RedBlackTree<Key, Value>::RedBlackTree() {
 
 template <typename Key, typename Value>
 void RedBlackTree<Key, Value>::insert(const Key& key, const Value& value) {
-    maxKeyLen = std::max(maxKeyLen, StringHandler::size(key));
+    this->setMaxKeyLen(key);
 	maxValLen = std::max(maxValLen, StringHandler::size(value));
 
     RedBlackNode<Key, Value> *z = new RedBlackNode<Key, Value>(key, value, NIL, NIL, NIL, RED);
@@ -324,7 +324,7 @@ size_t RedBlackTree<Key, Value>::getComparisonsCount() const {
 
 template <typename Key, typename Value>
 Value& RedBlackTree<Key, Value>::operator[](const Key& key) {
-    maxKeyLen = std::max(maxKeyLen, StringHandler::size(key));
+    this->setMaxKeyLen(key);
 
     RedBlackNode<Key, Value> *z = new RedBlackNode<Key, Value>(key, Value(), NIL, NIL, NIL, RED);
 
@@ -339,12 +339,12 @@ Value& RedBlackTree<Key, Value>::operator[](const Key& key) {
         } else if (z->getKey() > x->getKey()) {
             x = x->right;
         } else {
-            maxValLen = std::max(maxValLen, StringHandler::size(x->getValue()));
+            this->setMaxValLen(x->getValue());        
             return x->getValue();
         }
     }
 
-    maxValLen = std::max(maxValLen, StringHandler::size(z->getValue()));
+    this->setMaxValLen(z->getValue());
 
     z->parent = y;
     if (y == NIL) 

--- a/include/Trees/RedBlack/RedBlackTree.impl.hpp
+++ b/include/Trees/RedBlack/RedBlackTree.impl.hpp
@@ -100,10 +100,18 @@ RedBlackNode<Key, Value>* const RedBlackTree<Key, Value>::NIL = new RedBlackNode
 );
 
 template <typename Key, typename Value>
-RedBlackTree<Key, Value>::RedBlackTree() { root = NIL; }
+RedBlackTree<Key, Value>::RedBlackTree() {
+    root = NIL;
+    comparisonsCount = 0;
+    maxKeyLen = 0;
+    maxValLen = 0;
+}
 
 template <typename Key, typename Value>
 void RedBlackTree<Key, Value>::insert(const Key& key, const Value& value) {
+    maxKeyLen = std::max(maxKeyLen, StringHandler::size(key));
+	maxValLen = std::max(maxValLen, StringHandler::size(value));
+
     RedBlackNode<Key, Value> *z = new RedBlackNode<Key, Value>(key, value, NIL, NIL, NIL, RED);
 
     RedBlackNode<Key, Value> *x = root, *y = NIL;
@@ -316,6 +324,8 @@ size_t RedBlackTree<Key, Value>::getComparisonsCount() const {
 
 template <typename Key, typename Value>
 Value& RedBlackTree<Key, Value>::operator[](const Key& key) {
+    maxKeyLen = std::max(maxKeyLen, StringHandler::size(key));
+
     RedBlackNode<Key, Value> *z = new RedBlackNode<Key, Value>(key, Value(), NIL, NIL, NIL, RED);
 
     RedBlackNode<Key, Value> *x = root, *y = NIL;
@@ -329,9 +339,12 @@ Value& RedBlackTree<Key, Value>::operator[](const Key& key) {
         } else if (z->getKey() > x->getKey()) {
             x = x->right;
         } else {
+            maxValLen = std::max(maxValLen, StringHandler::size(x->getValue()));
             return x->getValue();
         }
     }
+
+    maxValLen = std::max(maxValLen, StringHandler::size(z->getValue()));
 
     z->parent = y;
     if (y == NIL) 
@@ -341,7 +354,6 @@ Value& RedBlackTree<Key, Value>::operator[](const Key& key) {
     else
         y->right = z;
 
-    // should I increment counter here?
     this->incrementCounter();
 
     insertFixup(z);

--- a/include/Trees/RedBlack/RedBlackTree.impl.hpp
+++ b/include/Trees/RedBlack/RedBlackTree.impl.hpp
@@ -326,23 +326,23 @@ template <typename Key, typename Value>
 Value& RedBlackTree<Key, Value>::operator[](const Key& key) {
     this->setMaxKeyLen(key);
 
-    RedBlackNode<Key, Value> *z = new RedBlackNode<Key, Value>(key, Value(), NIL, NIL, NIL, RED);
-
     RedBlackNode<Key, Value> *x = root, *y = NIL;
     
     while (x != NIL) {
         y = x;
 
         this->incrementCounter();
-        if (z->getKey() < x->getKey()) {
+        if (key < x->getKey()) {
             x = x->left;
-        } else if (z->getKey() > x->getKey()) {
+        } else if (key > x->getKey()) {
             x = x->right;
         } else {
             this->setMaxValLen(x->getValue());        
             return x->getValue();
         }
     }
+
+    RedBlackNode<Key, Value> *z = new RedBlackNode<Key, Value>(key, Value(), NIL, NIL, NIL, RED);
 
     this->setMaxValLen(z->getValue());
 

--- a/test_print_avl.cpp
+++ b/test_print_avl.cpp
@@ -1,0 +1,14 @@
+#include "Trees/AVL/AVLTree.hpp"
+
+int main() {
+    AVLTree<std::string, int> avl;
+
+    avl["Érica"] = 0;
+    avl["Bruna"] = 1;
+    avl["Paulo"] = 2;
+    avl["Mislayne"] = 2;
+
+    avl.printInOrder(std::cout);
+
+    return 0;
+}


### PR DESCRIPTION
This pull request introduces enhancements to the AVL and Red-Black tree implementations to support formatted output by tracking the maximum display lengths of keys and values. It also includes utility integrations and a new test file for verifying the changes. Below is a summary of the most important changes:

### Enhancements to AVL and Red-Black Trees:

* Added `maxKeyLen` and `maxValLen` member variables to `AVLTree` and `RedBlackTree` to track the maximum lengths of keys and values for formatted output. (`include/Trees/AVL/AVLTree.hpp`, `include/Trees/RedBlack/RedBlackTree.hpp`) [[1]](diffhunk://#diff-43a3f2a8c6dd4de856f3e821f789439dc185b5659b5f66ea289e375346962a9eR26-R27) [[2]](diffhunk://#diff-f778eac37e48e60747713aaabdda1e8ad791f58339220c1984d569dbdf5f5cceR27-R28)
* Updated the `insert` and `upsert` methods in `AVLTree` and `operator[]` in `RedBlackTree` to update `maxKeyLen` and `maxValLen` dynamically during key-value operations. (`include/Trees/AVL/AVLTree.impl.hpp`, `include/Trees/RedBlack/RedBlackTree.impl.hpp`) [[1]](diffhunk://#diff-08a2657ec76b9bd2ab6cc34d838f300c326b8153305f220fa0e5aa29e40cc304R163-R168) [[2]](diffhunk://#diff-512690464c187f535dc48af52759f8f690c694c80b99212e638cf341dec71919L319-R348)

### Integration of Utility Functions:

* Integrated `StringHandler` utilities to format tree output by setting consistent widths for keys and values during in-order traversal. (`include/Trees/Base/BaseTree.impl.hpp`)
* Added `setMaxKeyLen` and `setMaxValLen` methods to `BaseTree` for updating maximum key and value lengths using CRTP. (`include/Trees/Base/BaseTree.hpp`, `include/Trees/Base/BaseTree.impl.hpp`) [[1]](diffhunk://#diff-9dbde41304be07be62d1b0bed852a127347530c14de5a59968b22808d03eb7e6R87-R90) [[2]](diffhunk://#diff-b8312d0863f2481f137ad15487907e196b6552e818ce77c06eee4031823cafe7R94-R103)

### Codebase Improvements:

* Modified constructors for `AVLTree` and `RedBlackTree` to initialize `maxKeyLen` and `maxValLen` to zero. (`include/Trees/AVL/AVLTree.impl.hpp`, `include/Trees/RedBlack/RedBlackTree.impl.hpp`) [[1]](diffhunk://#diff-08a2657ec76b9bd2ab6cc34d838f300c326b8153305f220fa0e5aa29e40cc304R180-R197) [[2]](diffhunk://#diff-512690464c187f535dc48af52759f8f690c694c80b99212e638cf341dec71919L103-R114)
* Updated the `printInOrder` method in `BaseTree` to use formatted output for nodes. (`include/Trees/Base/BaseTree.impl.hpp`)

### New Test File:

* Added `test_print_avl.cpp` to test formatted in-order traversal of an `AVLTree` with string keys and integer values. (`test_print_avl.cpp`)