### PR TITLE
feat: factory of dictionaries

### DIFF
--- a/include/Exceptions/FactoryExceptions.hpp
+++ b/include/Exceptions/FactoryExceptions.hpp
@@ -1,0 +1,26 @@
+#ifndef FACTORY_EXCEPTIONS_HPP
+#define FACTORY_EXCEPTIONS_HPP
+
+#include <stdexcept>
+
+/**
+ * @class DictionaryTypeNotFound
+ * @brief Exception thrown when a requested dictionary type is not found in the factory.
+ *
+ * This class inherits from std::runtime_error. It is used to signal an error
+ * when an attempt is made to create a dictionary with a type name that the
+ * factory does not recognize.
+ */
+class DictionaryTypeNotFound : public std::runtime_error {
+public:
+    /**
+     * @brief Constructs the exception object.
+     *
+     * Initializes the base class std::runtime_error with a default error message.
+     * @post The exception object is created with the message "Dictionary type not found.".
+     */
+    explicit DictionaryTypeNotFound()
+        : std::runtime_error("Dictionary type not found.") {}
+};
+
+#endif

--- a/include/Exceptions/FactoryExceptions.hpp
+++ b/include/Exceptions/FactoryExceptions.hpp
@@ -7,20 +7,20 @@
  * @class DictionaryTypeNotFound
  * @brief Exception thrown when a requested dictionary type is not found in the factory.
  *
- * This class inherits from std::runtime_error. It is used to signal an error
+ * This class inherits from std::out_of_range. It is used to signal an error
  * when an attempt is made to create a dictionary with a type name that the
  * factory does not recognize.
  */
-class DictionaryTypeNotFound : public std::runtime_error {
+class DictionaryTypeNotFound : public std::out_of_range {
 public:
     /**
      * @brief Constructs the exception object.
      *
-     * Initializes the base class std::runtime_error with a default error message.
+     * Initializes the base class std::out_of_range with a default error message.
      * @post The exception object is created with the message "Dictionary type not found.".
      */
     explicit DictionaryTypeNotFound()
-        : std::runtime_error("Dictionary type not found.") {}
+        : std::out_of_range("Dictionary type not found.") {}
 };
 
 #endif

--- a/include/Factory/DictionaryFactory.hpp
+++ b/include/Factory/DictionaryFactory.hpp
@@ -1,0 +1,59 @@
+#ifndef DICTIONARY_FACTORY_HPP
+#define DICTIONARY_FACTORY_HPP
+
+#include "Dictionary/IDictionary.hpp"
+#include "Trees/AVL/AVLTree.hpp"
+#include "Trees/RedBlack/RedBlackTree.hpp"
+#include "HashTables/Chained/ChainedHashTable.hpp"
+#include "HashTables/OpenAddressing/OpenAddressingHashTable.hpp"
+#include "Exceptions/FactoryExceptions.hpp"
+
+/**
+ * @class DictionaryFactory
+ * @brief A factory class for creating instances of dictionary data structures.
+ *
+ * This class provides a static method to create different implementations of the
+ * IDictionary interface based on a string identifier. This encapsulates the
+ * instantiation logic and promotes loose coupling.
+ *
+ * @tparam Key The type of the keys in the dictionary.
+ * @tparam Value The type of the values in the dictionary.
+ */
+template <typename Key, typename Value>
+class DictionaryFactory {
+public:
+    /**
+     * @brief Creates a dictionary instance based on the specified type.
+     *
+     * This static factory method returns a pointer to a new dictionary object
+     * that implements the IDictionary interface. The concrete type of the object
+     * is determined by the `dictType` string.
+     *
+     * @param dictType A string specifying the dictionary type to create.
+     * Valid options are:
+     * - "avl_dictionary"
+     * - "redblack_dictionary"
+     * - "chained_dictionary"
+     * - "open_dictionary"
+     * @return IDictionary<Key, Value>* A pointer to the newly created dictionary instance.
+     * The caller is responsible for deleting this object.
+     * @throw DictionaryTypeNotFound If the `dictType` does not match any known type.
+     */
+    static IDictionary<Key, Value>* createDictionary(const std::string& dictType) {
+        if (dictType == "avl_dictionary")
+            return new AVLTree<Key, Value>();
+
+        if (dictType == "redblack_dictionary")
+            return new RedBlackTree<Key, Value>();
+
+        if (dictType == "chained_dictionary")
+            return new ChainedHashTable<Key, Value>();
+
+        if (dictType == "open_dictionary")
+            return new OpenAddressingHashTable<Key, Value>();
+
+        throw DictionaryTypeNotFound();
+    }
+};
+
+#endif

--- a/include/Factory/DictionaryFactory.hpp
+++ b/include/Factory/DictionaryFactory.hpp
@@ -1,12 +1,15 @@
 #ifndef DICTIONARY_FACTORY_HPP
 #define DICTIONARY_FACTORY_HPP
 
+#include <memory>
+
 #include "Dictionary/IDictionary.hpp"
 #include "Trees/AVL/AVLTree.hpp"
 #include "Trees/RedBlack/RedBlackTree.hpp"
 #include "HashTables/Chained/ChainedHashTable.hpp"
 #include "HashTables/OpenAddressing/OpenAddressingHashTable.hpp"
 #include "Exceptions/FactoryExceptions.hpp"
+#include "Factory/DictionaryType.hpp"
 
 /**
  * @class DictionaryFactory
@@ -39,20 +42,19 @@ public:
      * The caller is responsible for deleting this object.
      * @throw DictionaryTypeNotFound If the `dictType` does not match any known type.
      */
-    static IDictionary<Key, Value>* createDictionary(const std::string& dictType) {
-        if (dictType == "avl_dictionary")
-            return new AVLTree<Key, Value>();
-
-        if (dictType == "redblack_dictionary")
-            return new RedBlackTree<Key, Value>();
-
-        if (dictType == "chained_dictionary")
-            return new ChainedHashTable<Key, Value>();
-
-        if (dictType == "open_dictionary")
-            return new OpenAddressingHashTable<Key, Value>();
-
-        throw DictionaryTypeNotFound();
+    static std::unique_ptr<IDictionary<Key, Value>> createDictionary(DictionaryType dictType) {
+        switch (dictType) {
+            case DictionaryType::AVL: 
+                return std::make_unique<AVLTree<Key, Value>>();
+            case DictionaryType::RedBlack: 
+                return std::make_unique<RedBlackTree<Key, Value>>();
+            case DictionaryType::Chained: 
+                return std::make_unique<ChainedHashTable<Key, Value>>();
+            case DictionaryType::OpenAddressing: 
+                return std::make_unique<OpenAddressingHashTable<Key, Value>>();
+            default: 
+                throw DictionaryTypeNotFound();
+        }
     }
 };
 

--- a/include/Factory/DictionaryType.hpp
+++ b/include/Factory/DictionaryType.hpp
@@ -1,0 +1,13 @@
+#ifndef DICTIONARY_TYPE_HPP
+#define DICTIONARY_TYPE_HPP
+
+/**
+ * @brief Defines the types of dictionary data structures available.
+ *
+ * This enumeration is used to uniquely identify the different concrete
+ * implementations of the dictionary interface, often used by a factory
+ * to determine which object to create.
+ */
+enum class DictionaryType { AVL, RedBlack, Chained, OpenAddressing };
+
+#endif

--- a/include/Trees/AVL/AVLTree.hpp
+++ b/include/Trees/AVL/AVLTree.hpp
@@ -141,7 +141,7 @@ private:
      */
     AVLNode<Key, Value>* upsert(const Key& key, AVLNode<Key, Value>* node, Value*& outValue);
 
-    public:
+public:
     static const int IMBALANCE = 2; ///< The imbalance threshold for the AVL tree.
     
     /**

--- a/include/Utils/StringDictionaryTypeMap.hpp
+++ b/include/Utils/StringDictionaryTypeMap.hpp
@@ -1,0 +1,24 @@
+#ifndef STRING_DICTIONARY_TYPE_HPP
+#define STRING_DICTIONARY_TYPE_HPP
+
+#include <unordered_map>
+#include <string>
+
+#include "Factory/DictionaryType.hpp"
+
+/**
+ * @brief A constant map to convert string identifiers to DictionaryType enums.
+ *
+ * This unordered_map provides a convenient and efficient way to look up the
+ * corresponding DictionaryType enum value from a human-readable string. It is
+ * typically used to parse user input or configuration settings to determine
+ * which dictionary implementation should be instantiated by a factory.
+ */
+const std::unordered_map<std::string, DictionaryType> stringDicitionaryTypeMap = {
+    {"dictionary_avl", DictionaryType::AVL},
+    {"dictionary_redblack", DictionaryType::RedBlack},
+    {"dictionary_chained", DictionaryType::Chained},
+    {"dictionary_open", DictionaryType::OpenAddressing}
+};
+
+#endif

--- a/include/Utils/StringDictionaryTypeMap.hpp
+++ b/include/Utils/StringDictionaryTypeMap.hpp
@@ -14,7 +14,7 @@
  * typically used to parse user input or configuration settings to determine
  * which dictionary implementation should be instantiated by a factory.
  */
-const std::unordered_map<std::string, DictionaryType> stringDicitionaryTypeMap = {
+const std::unordered_map<std::string, DictionaryType> stringDictionaryTypeMap = {
     {"dictionary_avl", DictionaryType::AVL},
     {"dictionary_redblack", DictionaryType::RedBlack},
     {"dictionary_chained", DictionaryType::Chained},

--- a/include/Utils/StringHandler.hpp
+++ b/include/Utils/StringHandler.hpp
@@ -3,6 +3,8 @@
 
 #include <string>
 
+#include "Factory/DictionaryType.hpp"
+
 namespace StringHandler {
     /**
      * @brief A manipulator to set the width and left-align an object when streamed.
@@ -50,6 +52,20 @@ namespace StringHandler {
      */
     template <typename Object>
     std::ostream& operator<<(std::ostream& os, const SetWidthAtLeft<Object>& manip);
+
+    /**
+     * @brief Converts a string identifier to a DictionaryType enum.
+     *
+     * This function attempts to find the given string `str` as a key in the
+     * global `stringDicitionaryTypeMap`. If successful, it returns the
+     * corresponding `DictionaryType` value.
+     *
+     * @param str The string representation of the dictionary type to convert.
+     * @return The corresponding `DictionaryType` enum value.
+     * @throw DictionaryTypeNotFound if the string does not correspond to a valid
+     * dictionary type in the map.
+     */
+    DictionaryType toDictionaryType(const std::string& str);
 }
 
 #include "Utils/StringHandler.impl.hpp"

--- a/include/Utils/StringHandler.impl.hpp
+++ b/include/Utils/StringHandler.impl.hpp
@@ -2,6 +2,9 @@
 
 #include <sstream>
 
+#include "Utils/StringDictionaryTypeMap.hpp"
+#include "Exceptions/FactoryExceptions.hpp"
+
 #include "utf8.h"
 
 namespace StringHandler {
@@ -38,5 +41,13 @@ namespace StringHandler {
         os << str << std::string(padding, ' ');
 
         return os;
+    }
+
+    DictionaryType toDictionaryType(const std::string& str) {
+        try {
+            return stringDicitionaryTypeMap.at(str);
+        } catch(const std::out_of_range& e) {
+            throw DictionaryTypeNotFound();
+        }
     }
 }

--- a/include/Utils/StringHandler.impl.hpp
+++ b/include/Utils/StringHandler.impl.hpp
@@ -45,7 +45,7 @@ namespace StringHandler {
 
     DictionaryType toDictionaryType(const std::string& str) {
         try {
-            return stringDicitionaryTypeMap.at(str);
+            return stringDictionaryTypeMap.at(str);
         } catch(const std::out_of_range& e) {
             throw DictionaryTypeNotFound();
         }

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,11 @@
+#include "Factory/DictionaryFactory.hpp"
+
+int main() {
+    std::unique_ptr<IDictionary<std::string, int>> dict = DictionaryFactory<std::string, int>::createDictionary(StringHandler::toDictionaryType("dictionary_avl"));
+
+    dict->insert("Emilson", 8);
+    (*dict)["Emilson"]++;
+    (*dict)["Alessandra"]++;
+
+    dict->printInOrder(std::cout);
+}


### PR DESCRIPTION
This pull request introduces a factory-based design for creating dictionary data structures, along with supporting utilities for mapping string identifiers to dictionary types. The changes include the addition of a `DictionaryFactory` class, a new exception for handling invalid dictionary types, and utility functions for mapping and converting dictionary type identifiers.

### Factory Implementation and Exception Handling:
* Added `DictionaryFactory` class in `include/Factory/DictionaryFactory.hpp` to create dictionary instances based on a `DictionaryType` enum. It supports AVL, Red-Black, Chained Hash Table, and Open Addressing Hash Table implementations. Throws `DictionaryTypeNotFound` for invalid types.
* Introduced `DictionaryTypeNotFound` exception in `include/Exceptions/FactoryExceptions.hpp` for handling cases where an invalid dictionary type is requested.

### Dictionary Type Mapping:
* Added `DictionaryType` enum in `include/Factory/DictionaryType.hpp` to define supported dictionary types.
* Created a constant map `stringDicitionaryTypeMap` in `include/Utils/StringDictionaryTypeMap.hpp` to map string identifiers to `DictionaryType` enum values.

### String Conversion Utility:
* Added `toDictionaryType` function in `include/Utils/StringHandler.hpp` and implemented it in `include/Utils/StringHandler.impl.hpp`. This function converts a string to a `DictionaryType` using `stringDicitionaryTypeMap` and throws `DictionaryTypeNotFound` for invalid strings. [[1]](diffhunk://#diff-5718f49d80e4ea2b9ae57088c8c966caa72ff948c3e9f8d0156ea040fb281a15R55-R68) [[2]](diffhunk://#diff-1cb587352f9f4c3d5a302ac210486a6ff8e80e0d7f70a149ff6eb69d040fb599R45-R52)

### Example Usage:
* Updated `main.cpp` to demonstrate the usage of `DictionaryFactory` and the new utilities by creating an AVL-based dictionary and performing basic operations like insertion and in-order printing.