### PR TITLE
Feat/visitor pattern

### DIFF
--- a/include/Dictionary/IDictionary.hpp
+++ b/include/Dictionary/IDictionary.hpp
@@ -111,6 +111,17 @@ public:
      */
     virtual ~IDictionary() = default;
 
+    /**
+     * @brief Accepts a visitor that performs operations on the dictionary.
+     * 
+     * This method allows an external visitor object to interact with the dictionary
+     * by implementing the IDictionaryVisitor interface. The visitor can perform
+     * custom operations on the dictionary's keys and values without exposing
+     * the internal structure of the dictionary.
+     * 
+     * @param visitor A reference to an object implementing the IDictionaryVisitor
+     * interface, which defines the operations to be performed on the dictionary.
+     */
     virtual void accept(IDictionaryVisitor<Key, Value>& visitor) const = 0;
     
     template <typename Tree, typename Node, typename K, typename V>

--- a/include/Dictionary/IDictionary.hpp
+++ b/include/Dictionary/IDictionary.hpp
@@ -2,6 +2,7 @@
 #define IDICTIONARY_HPP
 
 #include "Trees/Base/BaseTree.hpp"
+#include "Visitor/IDictionaryVisitor.hpp"
 
 /**
  * @brief Interface for a generic dictionary data structure.
@@ -109,6 +110,8 @@ public:
      * @brief Virtual destructor.
      */
     virtual ~IDictionary() = default;
+
+    virtual void accept(IDictionaryVisitor<Key, Value>& visitor) const = 0;
     
     template <typename Tree, typename Node, typename K, typename V>
     friend class BaseTree;

--- a/include/HashTables/Chained/ChainedHashTable.hpp
+++ b/include/HashTables/Chained/ChainedHashTable.hpp
@@ -297,6 +297,11 @@ public:
      */
     void print() const;
 
+    /**
+     * @brief Accepts a visitor implementing IDictionaryVisitor interface to collect metrics or perform operations on the ChainedHashTable.
+     * 
+     * @param visitor A reference to an IDictionaryVisitor<Key, Value> object that will interact with the ChainedHashTable.
+     */
     void accept(IDictionaryVisitor<Key, Value>& visitor) const override;
 };
 

--- a/include/HashTables/Chained/ChainedHashTable.hpp
+++ b/include/HashTables/Chained/ChainedHashTable.hpp
@@ -296,6 +296,8 @@ public:
      * purposes.
      */
     void print() const;
+
+    void accept(IDictionaryVisitor<Key, Value>& visitor) const override;
 };
 
 #include "HashTables/Chained/ChainedHashTable.impl.hpp"

--- a/include/HashTables/Chained/ChainedHashTable.impl.hpp
+++ b/include/HashTables/Chained/ChainedHashTable.impl.hpp
@@ -212,3 +212,8 @@ void ChainedHashTable<Key, Value, Hash>::print() const {
         std::cout << "\n";
     }
 }
+
+template <typename Key, typename Value, typename Hash>
+void ChainedHashTable<Key, Value, Hash>::accept(IDictionaryVisitor<Key, Value>& visitor) {
+	visitor.collectMetrics(*this);
+}

--- a/include/HashTables/OpenAddressing/OpenAddressingHashTable.hpp
+++ b/include/HashTables/OpenAddressing/OpenAddressingHashTable.hpp
@@ -275,6 +275,11 @@ public:
      */
     void print() const;
 
+    /**
+     * @brief Accepts a visitor implementing IDictionaryVisitor interface to collect metrics or perform operations on the OpenAddresingHashTable.
+     * 
+     * @param visitor A reference to an IDictionaryVisitor<Key, Value> object that will interact with the OpenAddresingHashTable.
+     */
     void accept(IDictionaryVisitor<Key, Value>& visitor) const = 0;
 };
 

--- a/include/HashTables/OpenAddressing/OpenAddressingHashTable.hpp
+++ b/include/HashTables/OpenAddressing/OpenAddressingHashTable.hpp
@@ -274,6 +274,8 @@ public:
      * @param out The output stream where the slot information will be printed.
      */
     void print() const;
+
+    void accept(IDictionaryVisitor<Key, Value>& visitor) const = 0;
 };
 
 #include "HashTables/OpenAddressing/OpenAddressingHashTable.impl.hpp"

--- a/include/HashTables/OpenAddressing/OpenAddressingHashTable.impl.hpp
+++ b/include/HashTables/OpenAddressing/OpenAddressingHashTable.impl.hpp
@@ -264,3 +264,8 @@ void OpenAddressingHashTable<Key, Value, Hash>::print() const {
         std::cout << '\n';
     }
 }
+
+template <typename Key, typename Value, typename Hash>
+void OpenAddressingHashTable<Key, Value, Hash>::accept(IDictionaryVisitor<Key, Value>& visitor) {
+	visitor.collectMetrics(*this);
+}

--- a/include/Reports/ReportData.hpp
+++ b/include/Reports/ReportData.hpp
@@ -1,0 +1,15 @@
+#ifndef REPORT_DATA_HPP
+#define REPORT_DATA_HPP
+
+#include <string>
+#include <chrono>
+
+struct ReportData {
+    std::string dictionarType;
+    std::chrono::nanoseconds buildTime;
+    size_t comparisons;
+    std::pair<std::string, size_t> specificMetric;
+    size_t totalWordsProcessed;    
+};
+
+#endif

--- a/include/Trees/AVL/AVLTree.hpp
+++ b/include/Trees/AVL/AVLTree.hpp
@@ -241,6 +241,11 @@ public:
      */
     size_t getRotationsCount() const;
 
+    /**
+     * @brief Accepts a visitor implementing IDictionaryVisitor interface to collect metrics or perform operations on the AVLTree.
+     * 
+     * @param visitor A reference to an IDictionaryVisitor<Key, Value> object that will interact with the AVLTree.
+     */
     void accept(IDictionaryVisitor<Key, Value>& visitor) const override;
 };
 

--- a/include/Trees/AVL/AVLTree.hpp
+++ b/include/Trees/AVL/AVLTree.hpp
@@ -240,6 +240,8 @@ public:
      * @return size_t The number of rotations performed.
      */
     size_t getRotationsCount() const;
+
+    void accept(IDictionaryVisitor<Key, Value>& visitor) const override;
 };
 
 #include "Trees/AVL/AVLTree.impl.hpp"

--- a/include/Trees/AVL/AVLTree.impl.hpp
+++ b/include/Trees/AVL/AVLTree.impl.hpp
@@ -273,3 +273,8 @@ template <typename Key, typename Value>
 size_t AVLTree<Key, Value>::getRotationsCount() const {
 	return this->rotationsCount;
 }
+
+template <typename Key, typename Value>
+void AVLTree<Key, Value>::accept(IDictionaryVisitor& visitor) {
+	visitor.collectMetrics(*this);
+}

--- a/include/Trees/RedBlack/RedBlackTree.hpp
+++ b/include/Trees/RedBlack/RedBlackTree.hpp
@@ -176,6 +176,11 @@ public:
      */
     size_t getRotationsCount() const;
 
+    /**
+     * @brief Accepts a visitor implementing IDictionaryVisitor interface to collect metrics or perform operations on the RedBlackTree.
+     * 
+     * @param visitor A reference to an IDictionaryVisitor<Key, Value> object that will interact with the RedBlackTree.
+     */
     void accept(IDictionaryVisitor<Key, Value>& visitor) const override;
 };
 

--- a/include/Trees/RedBlack/RedBlackTree.hpp
+++ b/include/Trees/RedBlack/RedBlackTree.hpp
@@ -175,6 +175,8 @@ public:
      * @return size_t The total number of rotations performed.
      */
     size_t getRotationsCount() const;
+
+    void accept(IDictionaryVisitor<Key, Value>& visitor) const override;
 };
 
 #include "Trees/RedBlack/RedBlackTree.impl.hpp"

--- a/include/Trees/RedBlack/RedBlackTree.impl.hpp
+++ b/include/Trees/RedBlack/RedBlackTree.impl.hpp
@@ -383,3 +383,8 @@ template <typename Key, typename Value>
 size_t RedBlackTree<Key, Value>::getRotationsCount() const {
     return this->rotationsCount;
 }
+
+template <typename Key, typename Value>
+void RedBlackTree<Key, Value>::accept(IDictionaryVisitor<Key, Value>& visitor) {
+	visitor.collectMetrics(*this);
+}

--- a/include/Visitor/IDictionaryVisitor.hpp
+++ b/include/Visitor/IDictionaryVisitor.hpp
@@ -1,0 +1,20 @@
+#ifndef IDICTIONARY_VISITOR_HPP
+#define IDICTIONARY_VISITOR_HPP
+
+#include "Trees/AVL/AVLTree.hpp"
+#include "Trees/RedBlack/RedBlackTree.hpp"
+#include "HashTables/Chained/ChainedHashTable.hpp"
+#include "HashTables/OpenAddressing/OpenAddressingHashTable.hpp"
+
+#include <utility>
+
+template <typename Key, typename Value, typename Hash = std::hash<Key>>
+class IDictionaryVisitor {
+public:
+    void collectMetrics(const AVLTree<Key, Value>& avlTree) = 0;
+    void collectMetrics(const RedBlackTree<Key, Value>& redBlackTree) = 0;
+    void collectMetrics(const ChainedHashTable<Key, Value>& chainedHashTable) = 0;
+    void collectMetrics(const OpenAddressingHashTable<Key, Value>& openAddressingHashTable) = 0;
+};
+
+#endif

--- a/include/Visitor/IDictionaryVisitor.hpp
+++ b/include/Visitor/IDictionaryVisitor.hpp
@@ -11,10 +11,10 @@
 template <typename Key, typename Value, typename Hash = std::hash<Key>>
 class IDictionaryVisitor {
 public:
-    void collectMetrics(const AVLTree<Key, Value>& avlTree) = 0;
-    void collectMetrics(const RedBlackTree<Key, Value>& redBlackTree) = 0;
-    void collectMetrics(const ChainedHashTable<Key, Value>& chainedHashTable) = 0;
-    void collectMetrics(const OpenAddressingHashTable<Key, Value>& openAddressingHashTable) = 0;
+    virtual void collectMetrics(const AVLTree<Key, Value>& avlTree) = 0;
+    virtual void collectMetrics(const RedBlackTree<Key, Value>& redBlackTree) = 0;
+    virtual void collectMetrics(const ChainedHashTable<Key, Value>& chainedHashTable) = 0;
+    virtual void collectMetrics(const OpenAddressingHashTable<Key, Value>& openAddressingHashTable) = 0;
 };
 
 #endif

--- a/include/Visitor/IDictionaryVisitor.hpp
+++ b/include/Visitor/IDictionaryVisitor.hpp
@@ -8,13 +8,67 @@
 
 #include <utility>
 
+
+/**
+ * @class IDictionaryVisitor
+ * @brief An interface (abstract class) for a visitor that collects metrics from dictionary data structures.
+ *
+ * This class defines the contract for implementing the Visitor design pattern. Concrete
+ * implementations of this interface can perform operations, such as collecting performance
+ * metrics, on various dictionary-like data structures without modifying their source code.
+ *
+ * @tparam Key The type of the keys stored in the dictionary.
+ * @tparam Value The type of the values stored in the dictionary.
+ * @tparam Hash The hash function object type, used for hash-based structures.
+ * Defaults to std::hash<Key>.
+ */
 template <typename Key, typename Value, typename Hash = std::hash<Key>>
 class IDictionaryVisitor {
 public:
+    /**
+     * @brief Virtual destructor to ensure proper cleanup of derived classes.
+     */
+    virtual ~IDictionaryVisitor() = default;
+
+    /**
+     * @brief Pure virtual function to visit an AVLTree.
+     *
+     * A concrete visitor must implement this method to handle metric collection
+     * for an AVLTree.
+     *
+     * @param avlTree A constant reference to the AVLTree to be visited.
+     */
     virtual void collectMetrics(const AVLTree<Key, Value>& avlTree) = 0;
+
+    /**
+     * @brief Pure virtual function to visit a RedBlackTree.
+     *
+     * A concrete visitor must implement this method to handle metric collection
+     * for a RedBlackTree.
+     *
+     * @param redBlackTree A constant reference to the RedBlackTree to be visited.
+     */
     virtual void collectMetrics(const RedBlackTree<Key, Value>& redBlackTree) = 0;
-    virtual void collectMetrics(const ChainedHashTable<Key, Value>& chainedHashTable) = 0;
-    virtual void collectMetrics(const OpenAddressingHashTable<Key, Value>& openAddressingHashTable) = 0;
+
+    /**
+     * @brief Pure virtual function to visit a ChainedHashTable.
+     *
+     * A concrete visitor must implement this method to handle metric collection
+     * for a ChainedHashTable.
+     *
+     * @param chainedHashTable A constant reference to the ChainedHashTable to be visited.
+     */
+    virtual void collectMetrics(const ChainedHashTable<Key, Value, Hash>& chainedHashTable) = 0;
+
+    /**
+     * @brief Pure virtual function to visit an OpenAddressingHashTable.
+     *
+     * A concrete visitor must implement this method to handle metric collection
+     * for an OpenAddressingHashTable.
+     *
+     * @param openAddressingHashTable A constant reference to the OpenAddressingHashTable to be visited.
+     */
+    virtual void collectMetrics(const OpenAddressingHashTable<Key, Value, Hash>& openAddressingHashTable) = 0;
 };
 
 #endif

--- a/include/Visitor/ReportDataCollectorVisitor.hpp
+++ b/include/Visitor/ReportDataCollectorVisitor.hpp
@@ -7,19 +7,81 @@
 #include "Visitor/IDictionaryVisitor.hpp"
 #include "Reports/ReportData.hpp"
 
+
+/**
+ * @class ReportDataCollectorVisitor
+ * @brief Implements the visitor pattern to collect performance metrics from various dictionary data structures.
+ *
+ * This class visits different dictionary implementations (like AVL Trees, Red-Black Trees, and Hash Tables),
+ * extracts relevant metrics such as comparison counts, and populates a ReportData object.
+ *
+ * @tparam Key The key type of the elements in the dictionary.
+ * @tparam Value The value type of the elements in the dictionary.
+ */
 template <typename Key, typename Value>
 class ReportDataCollectorVisitor : public IDictionaryVisitor<Key, Value> {
+    /**
+     * @var report
+     * @brief A reference to the ReportData object where collected metrics will be stored.
+     */
     ReportData& report;
 
+    /**
+     * @brief Extracts the total number of comparisons from a dictionary and adds it to the report.
+     * @param dict The dictionary from which to retrieve the comparison count.
+     */
     void addComparisonsCount(const IDictionary& dict);
 
+    /**
+     * @brief Sets the type name of the dictionary being processed in the report.
+     * @param dictType A string representing the dictionary's type (e.g., "AVL Tree").
+     */
     void setDictionaryType(const std::string& dictType);
 public:
+    /**
+     * @brief Constructs a ReportDataCollectorVisitor.
+     * @param data A reference to the ReportData object that will be populated with metrics.
+     */
     ReportDataCollectorVisitor(ReportData& data);
 
+    /**
+     * @brief Collects performance metrics from an AVLTree.
+     *
+     * This method sets the dictionary type to "AVLTree" and records its comparison count
+     * in the ReportData object provided during construction.
+     *
+     * @param avlTree The AVLTree instance to be analyzed.
+     */
     void collectMetrics(const AVLTree<Key, Value>& avlTree);
+
+    /**
+     * @brief Collects performance metrics from a RedBlackTree.
+     *
+     * This method sets the dictionary type to "RedBlackTree" and records its comparison count
+     * in the ReportData object provided during construction.
+     *
+     * @param redBlackTree The RedBlackTree instance to be analyzed.
+     */
     void collectMetrics(const RedBlackTree<Key, Value>& redBlackTree);
+
+    /**
+     * @brief Collects performance metrics from a ChainedHashTable.
+     *
+     * This method sets the dictionary type to "ChainedHashTable" and records its comparison count
+     * in the ReportData object provided during construction.
+     *
+     * @param chainedHashTable The ChainedHashTable instance to be analyzed.
+     */
     void collectMetrics(const ChainedHashTable<Key, Value>& chainedHashTable);
+
+    /**
+     * @brief Collects performance metrics from an OpenAddressingHashTable.
+     *
+     * This method sets the dictionary type to "OpenAddressingHashTable" and records its comparison count
+     * in the ReportData object provided during construction.
+     *
+     * @param openAddressingHashTable The OpenAddressingHashTable instance to be analyzed.
+     */
     void collectMetrics(const OpenAddressingHashTable<Key, Value>& openAddressingHashTable);
 };
 

--- a/include/Visitor/ReportDataCollectorVisitor.hpp
+++ b/include/Visitor/ReportDataCollectorVisitor.hpp
@@ -3,15 +3,15 @@
 
 #include <functional>
 
+#include "Dictionary/IDictionary.hpp"
 #include "Visitor/IDictionaryVisitor.hpp"
 #include "Reports/ReportData.hpp"
 
-template <typename Key, typename Value, typename Hash = std::hash<Key>>
+template <typename Key, typename Value>
 class ReportDataCollectorVisitor : public IDictionaryVisitor<Key, Value> {
     ReportData& report;
 
-    template <typename Dictionary>
-    void addComparisonsCount(const Dictionary& dict);
+    void addComparisonsCount(const IDictionary& dict);
 
     void setDictionaryType(const std::string& dictType);
 public:

--- a/include/Visitor/ReportDataCollectorVisitor.hpp
+++ b/include/Visitor/ReportDataCollectorVisitor.hpp
@@ -1,0 +1,28 @@
+#ifndef REPORT_DATA_VISITOR_HPP
+#define REPORT_DATA_VISITOR_HPP
+
+#include <functional>
+
+#include "Visitor/IDictionaryVisitor.hpp"
+#include "Reports/ReportData.hpp"
+
+template <typename Key, typename Value, typename Hash = std::hash<Key>>
+class ReportDataCollectorVisitor : public IDictionaryVisitor<Key, Value> {
+    ReportData& report;
+
+    template <typename Dictionary>
+    void addComparisonsCount(const Dictionary& dict);
+
+    void setDictionaryType(const std::string& dictType);
+public:
+    ReportDataCollectorVisitor(ReportData& data);
+
+    void collectMetrics(const AVLTree<Key, Value>& avlTree);
+    void collectMetrics(const RedBlackTree<Key, Value>& redBlackTree);
+    void collectMetrics(const ChainedHashTable<Key, Value>& chainedHashTable);
+    void collectMetrics(const OpenAddressingHashTable<Key, Value>& openAddressingHashTable);
+};
+
+#include "Visitor/ReportDataCollectorVisitor.impl.hpp"
+
+#endif

--- a/include/Visitor/ReportDataCollectorVisitor.impl.hpp
+++ b/include/Visitor/ReportDataCollectorVisitor.impl.hpp
@@ -1,36 +1,43 @@
 #include "Visitor/ReportDataCollectorVisitor.hpp"
 
-template <typename Key, typename Value, typename Hash>
-template <typename Dictionary>
-void ReportDataCollectorVisitor<Key, Value, Hash>::addComparisonsCount(const Dictionary& dict) {
+template <typename Key, typename Value>
+void ReportDataCollectorVisitor<Key, Value, Hash>::addComparisonsCount(const IDictionary& dict) {
     report.comparisons = dict.getComparisonsCount();
 }
 
-template <typename Key, typename Value, typename Hash>
+template <typename Key, typename Value>
 void ReportDataCollectorVisitor<Key, Value, Hash>::setDictionaryType(const std::string& dictType) {
     report.dictionaryType = dictType;
 }
 
-template <typename Key, typename Value, typename Hash>
+template <typename Key, typename Value>
 ReportDataCollectorVisitor<Key, Value, Hash>::ReportDataCollectorVisitor(ReportData& data)
     : report(data) {}
 
-template <typename Key, typename Value, typename Hash>
+template <typename Key, typename Value>
 void ReportDataCollectorVisitor<Key, Value, Hash>::collectMetrics(const AVLTree<Key, Value>& avlTree) {
     setDictionaryType("Árvore AVL");
     addComparisonsCount(avlTree);
     report.specificMetric = {"rotações", avlTree.getRotationsCount()};
 }
 
-template <typename Key, typename Value, typename Hash>
+template <typename Key, typename Value>
 void ReportDataCollectorVisitor<Key, Value, Hash>::collectMetrics(const RedBlackTree<Key, Value>& redBlackTree) {
     setDictionaryType("Árvore Rubro-Negra");
     addComparisonsCount(redBlackTree);
-    report.specificMetric = {"rotações", avlTree.getRotationsCount()};
+    report.specificMetric = {"rotações", redBlackTree.getRotationsCount()};
 }
 
-template <typename Key, typename Value, typename Hash>
+template <typename Key, typename Value>
 void ReportDataCollectorVisitor<Key, Value, Hash>::collectMetrics(const ChainedHashTable<Key, Value>& chainedHashTable) {
     setDictionaryType("Tabela Hash por Encademaneto Exterior");
     addComparisonsCount(ChainedHashTable);
+    report.specificMetric = {"colisões", chainedHashTable.getCollisionsCount()};
+}
+
+template <typename Key, typename Value>
+void ReportDataCollectorVisitor::collectMetrics(const OpenAddressingHashTable<Key, Value, Hash>&) {
+    setDictionaryType("Tabela Hash por Endereçamento Aberto");
+    addComparisonsCount(OpenAddressingHashTable);
+    report.specificMetric = {"colisões", openAddressingHashTable.getCollisionsCount()};
 }

--- a/include/Visitor/ReportDataCollectorVisitor.impl.hpp
+++ b/include/Visitor/ReportDataCollectorVisitor.impl.hpp
@@ -1,0 +1,36 @@
+#include "Visitor/ReportDataCollectorVisitor.hpp"
+
+template <typename Key, typename Value, typename Hash>
+template <typename Dictionary>
+void ReportDataCollectorVisitor<Key, Value, Hash>::addComparisonsCount(const Dictionary& dict) {
+    report.comparisons = dict.getComparisonsCount();
+}
+
+template <typename Key, typename Value, typename Hash>
+void ReportDataCollectorVisitor<Key, Value, Hash>::setDictionaryType(const std::string& dictType) {
+    report.dictionaryType = dictType;
+}
+
+template <typename Key, typename Value, typename Hash>
+ReportDataCollectorVisitor<Key, Value, Hash>::ReportDataCollectorVisitor(ReportData& data)
+    : report(data) {}
+
+template <typename Key, typename Value, typename Hash>
+void ReportDataCollectorVisitor<Key, Value, Hash>::collectMetrics(const AVLTree<Key, Value>& avlTree) {
+    setDictionaryType("Árvore AVL");
+    addComparisonsCount(avlTree);
+    report.specificMetric = {"rotações", avlTree.getRotationsCount()};
+}
+
+template <typename Key, typename Value, typename Hash>
+void ReportDataCollectorVisitor<Key, Value, Hash>::collectMetrics(const RedBlackTree<Key, Value>& redBlackTree) {
+    setDictionaryType("Árvore Rubro-Negra");
+    addComparisonsCount(redBlackTree);
+    report.specificMetric = {"rotações", avlTree.getRotationsCount()};
+}
+
+template <typename Key, typename Value, typename Hash>
+void ReportDataCollectorVisitor<Key, Value, Hash>::collectMetrics(const ChainedHashTable<Key, Value>& chainedHashTable) {
+    setDictionaryType("Tabela Hash por Encademaneto Exterior");
+    addComparisonsCount(ChainedHashTable);
+}


### PR DESCRIPTION
This pull request introduces the Visitor design pattern to enable metric collection and operations on various dictionary-like data structures without exposing their internal implementations. Key changes include adding the `IDictionaryVisitor` interface, implementing visitor support in multiple data structures, and creating a concrete visitor for performance metric collection.

### Visitor Design Pattern Implementation:

* [`include/Visitor/IDictionaryVisitor.hpp`](diffhunk://#diff-0816f1d5ec52441278313cc575cb83b920cb115ff4c38737868726c29e3ed247R1-R74): Added the `IDictionaryVisitor` interface to define a contract for visitors that collect metrics from dictionary-like data structures. It includes methods for visiting `AVLTree`, `RedBlackTree`, `ChainedHashTable`, and `OpenAddressingHashTable`.

### Integration of Visitor Pattern into Data Structures:

* [`include/Dictionary/IDictionary.hpp`](diffhunk://#diff-97b4b52ac337aec28060657294cdfb2105cddd7f6fbc57052524a4aab2abf9f0R114-R126): Added the `accept` method to the `IDictionary` interface to allow dictionary objects to accept visitors.
* `include/HashTables/Chained/ChainedHashTable.hpp` and `include/HashTables/Chained/ChainedHashTable.impl.hpp`: Implemented the `accept` method in `ChainedHashTable` to allow visitor interaction. [[1]](diffhunk://#diff-696516a964b0403d8fc329c67663fb48f6c032f18c2d514417780721af8308fdR299-R305) [[2]](diffhunk://#diff-592858c2c8d5411b8349f34b870c9dd916607a3bce4f9cee07c853c331caf478R215-R219)
* `include/HashTables/OpenAddressing/OpenAddressingHashTable.hpp` and `include/HashTables/OpenAddressing/OpenAddressingHashTable.impl.hpp`: Added visitor support with the `accept` method in `OpenAddressingHashTable`. [[1]](diffhunk://#diff-1be270f0ad914b341054259ab95583d9d65b58e587844706f0f3f0292caa90e5R277-R283) [[2]](diffhunk://#diff-1c2f932035693173ac3df3952509ea8e53e6b688d1bae257710e750068c5c213R267-R271)
* `include/Trees/AVL/AVLTree.hpp` and `include/Trees/AVL/AVLTree.impl.hpp`: Integrated the `accept` method for visitor interaction in `AVLTree`. [[1]](diffhunk://#diff-43a3f2a8c6dd4de856f3e821f789439dc185b5659b5f66ea289e375346962a9eR243-R249) [[2]](diffhunk://#diff-08a2657ec76b9bd2ab6cc34d838f300c326b8153305f220fa0e5aa29e40cc304R276-R280)
* `include/Trees/RedBlack/RedBlackTree.hpp` and `include/Trees/RedBlack/RedBlackTree.impl.hpp`: Added the `accept` method to enable visitor operations in `RedBlackTree`. [[1]](diffhunk://#diff-f778eac37e48e60747713aaabdda1e8ad791f58339220c1984d569dbdf5f5cceR178-R184) [[2]](diffhunk://#diff-512690464c187f535dc48af52759f8f690c694c80b99212e638cf341dec71919R386-R390)

### Metric Collection and Reporting:

* [`include/Reports/ReportData.hpp`](diffhunk://#diff-2cc5cb19b99bba3b8c93d093bf8e4fa5edd5e3fd52545191f83b48d7a670689fR1-R15): Introduced the `ReportData` structure to store collected metrics such as dictionary type, build time, comparisons, specific metrics, and total words processed.
* `include/Visitor/ReportDataCollectorVisitor.hpp` and `include/Visitor/ReportDataCollectorVisitor.impl.hpp`: Implemented the `ReportDataCollectorVisitor` class to collect performance metrics from dictionary data structures and populate a `ReportData` object. [[1]](diffhunk://#diff-3b868237339124f2d4cefdd0335adba14af4f441a30cb8e48e555c0161a85f31R1-R90) [[2]](diffhunk://#diff-ab206bbfd4a41551d2d2fe31aa6b20c22e0dfcafb1e5c3fbca66ffd1141152deR1-R43)